### PR TITLE
Make DomainEvent.PartitionKey property virtual.

### DIFF
--- a/source/Khala.EventSourcing.Contracts/EventSourcing/DomainEvent.cs
+++ b/source/Khala.EventSourcing.Contracts/EventSourcing/DomainEvent.cs
@@ -13,7 +13,7 @@
         public DateTime RaisedAt { get; set; }
 
         [JsonIgnore]
-        public string PartitionKey => SourceId.ToString();
+        public virtual string PartitionKey => SourceId.ToString();
 
         public void Raise(IVersionedEntity source)
         {

--- a/source/Khala.EventSourcing.Tests.Core/EventSourcing/DomainEvent_specs.cs
+++ b/source/Khala.EventSourcing.Tests.Core/EventSourcing/DomainEvent_specs.cs
@@ -101,5 +101,13 @@
             sut.RaisedAt.Kind.Should().Be(DateTimeKind.Utc);
             sut.RaisedAt.Should().BeCloseTo(DateTime.UtcNow);
         }
+
+        [TestMethod]
+        public void PartitionKey_is_virtual()
+        {
+            PropertyInfo property = typeof(DomainEvent).GetProperty("PartitionKey");
+            bool isVirtual = property.GetGetMethod().IsVirtual;
+            isVirtual.Should().BeTrue();
+        }
     }
 }


### PR DESCRIPTION
Sometimes events from different aggregates may have the same
partitioning key. So, make DomainEvent.PartitionKey property to virtual.

this resolves #31 
